### PR TITLE
Remove warnings

### DIFF
--- a/XCDYouTubeKit/XCDYouTubePlayerScript.m
+++ b/XCDYouTubeKit/XCDYouTubePlayerScript.m
@@ -7,11 +7,6 @@
 #import <JavaScriptCore/JavaScriptCore.h>
 
 #import <Availability.h>
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0
-#warning Rewrite JavaScriptCore code with JSContext + JSValue (available since iOS 7) instead the verbose C API.
-#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9
-#warning Rewrite JavaScriptCore code with JSContext + JSValue (available since OS X 10.9) instead the verbose C API.
-#endif
 
 @interface XCDYouTubePlayerScript ()
 @property (nonatomic, assign) JSGlobalContextRef context;


### PR DESCRIPTION
Things that you'd like to implement in the future should not be warnings that show up at build time. I'd love to see this rewrite as well. I think these belong as GitHub issues and not warnings.

Thanks for your work on this!
