### PR TITLE
Fix: Quick switch to background -> black screen

### DIFF
--- a/XCDYouTubeKit Demo/iOS Demo/MPMoviePlayerController+BackgroundPlayback.m
+++ b/XCDYouTubeKit Demo/iOS Demo/MPMoviePlayerController+BackgroundPlayback.m
@@ -107,10 +107,12 @@ static void *PlayerKey = &PlayerKey;
 	}
 }
 
-+ (void) backgroundPlayback_applicationDidBecomeActive:(NSNotification *)notification
-{
-	AVPlayerLayer *playerLayer = PlayerLayer();
-	playerLayer.player = objc_getAssociatedObject(currentMoviePlayerController, PlayerKey);
++ (void)backgroundPlayback_applicationDidBecomeActive:(NSNotification *)notification {
+  AVPlayerLayer *playerLayer = PlayerLayer();
+  AVPlayer *player = objc_getAssociatedObject(currentMoviePlayerController, PlayerKey);
+  if (player) {
+    playerLayer.player = player;
+  }
 }
 
 @end


### PR DESCRIPTION
There is a chance, that you hit home button too quick, when PlayerLayer still have no Player.