### PR TITLE
Weird videos

### DIFF
--- a/XCDYouTubeKit/XCDYouTubeVideo.m
+++ b/XCDYouTubeKit/XCDYouTubeVideo.m
@@ -110,6 +110,8 @@ static NSDate * ExpirationDate(NSURL *streamURL)
 				return nil;
 			}
 			NSString *signature = [playerScript unscrambleSignature:scrambledSignature];
+			if (playerScript && scrambledSignature && !signature)
+				continue;
 			
 			NSString *urlString = stream[@"url"];
 			NSString *itag = stream[@"itag"];

--- a/XCDYouTubeKit/XCDYouTubeVideo.m
+++ b/XCDYouTubeKit/XCDYouTubeVideo.m
@@ -110,8 +110,6 @@ static NSDate * ExpirationDate(NSURL *streamURL)
 				return nil;
 			}
 			NSString *signature = [playerScript unscrambleSignature:scrambledSignature];
-			if (playerScript && !signature)
-				continue;
 			
 			NSString *urlString = stream[@"url"];
 			NSString *itag = stream[@"itag"];

--- a/XCDYouTubeKit/XCDYouTubeVideoOperation.m
+++ b/XCDYouTubeKit/XCDYouTubeVideoOperation.m
@@ -187,7 +187,7 @@ typedef NS_ENUM(NSUInteger, XCDYouTubeRequestType) {
 	if (self.webpage.isAgeRestricted)
 	{
 		NSString *eurl = [@"https://youtube.googleapis.com/v/" stringByAppendingString:self.videoIdentifier];
-		NSString *sts = [self.embedWebpage.playerConfiguration[@"sts"] description] ?: @"";
+		NSString *sts = [self.embedWebpage.playerConfiguration[@"sts"] description] ?: [self.webpage.playerConfiguration[@"sts"] description] ?: @"";
 		NSDictionary *query = @{ @"video_id": self.videoIdentifier, @"hl": self.languageIdentifier, @"eurl": eurl, @"sts": sts};
 		NSString *queryString = XCDQueryStringWithDictionary(query, NSUTF8StringEncoding);
 		NSURL *videoInfoURL = [NSURL URLWithString:[@"https://www.youtube.com/get_video_info?" stringByAppendingString:queryString]];


### PR DESCRIPTION
These commits fix some of the weird videos I've found that don't work in the current release.

On a branch I didn't push I added tests for them, but I couldn't figure out how to use the tests without putting ONLINE_TESTS in the environment.
Also, one of the tests doesn't work offline, since it actually checks the returned link.

So, I'll just outline the cases here, and you can use those to write tests as you see fit.

The first one, about age restricted videos, was to fix videos "FfM_wS7qYfY" and "pn1VGytzXus".
Both of them list an age restriction in their metadata, but don't present the sign in page. I don't know why, or what that means, but I've seen it.
Testing these videos, from my machine at least, gives a valid url, so the tests pass, but that url results in a 403 if it's fetched.
In order to help my own testing, I added code to make a head request against the url for format 18, and assert that the status code for that was not 403 (Forbidden).
I don't think this would work in offline, mode, though, so I didn't want to commit that test, because I'm not sure if you wanted it.

The second one is about video "PZp3xEdQc38", a video that runs that gamut of failures, ending up in XCDYouTubeVideoOperation's `startNextRequest` method's `self.eventLabels.count == 0` branch.
This kicks off a chain that fetches the watch page, which fetches the embed page, which fetches the javascript, which fetches the video_info page.
This leads us to have an unscramble function, since we went through the js at some point, but the video actually doesn't have an "s" parameter or require a signature to be generated.

So, I just took out the part that leads to that being considered an error case, and the rest of the logic seems to work out.
It doesn't appear to ruin any of the other tests.

Hopefully this is useful.