### PR TITLE
Parameter types of XCDYouTubeClient#getVideoWithIdentifie callback function aren't optional type in swift 2.0

### DIFF
--- a/XCDYouTubeKit/XCDYouTubeClient.h
+++ b/XCDYouTubeKit/XCDYouTubeClient.h
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An opaque object conforming to the `<XCDYouTubeOperation>` protocol for canceling the asynchronous video information operation. If you call the `cancel` method before the operation is finished, the completion handler will not be called. It is recommended that you store this opaque object as a weak property.
  */
-- (id<XCDYouTubeOperation>) getVideoWithIdentifier:(nullable NSString *)videoIdentifier completionHandler:(void (^)(XCDYouTubeVideo *video, NSError *error))completionHandler;
+- (id<XCDYouTubeOperation>) getVideoWithIdentifier:(nullable NSString *)videoIdentifier completionHandler:(void (^)(XCDYouTubeVideo * _Nullable video, NSError * _Nullable error))completionHandler;
 
 @end
 

--- a/XCDYouTubeKit/XCDYouTubeClient.m
+++ b/XCDYouTubeKit/XCDYouTubeClient.m
@@ -54,7 +54,7 @@
 	return _languageIdentifier;
 }
 
-- (id<XCDYouTubeOperation>) getVideoWithIdentifier:(NSString *)videoIdentifier completionHandler:(void (^)(XCDYouTubeVideo *video, NSError *error))completionHandler
+- (id<XCDYouTubeOperation>) getVideoWithIdentifier:(NSString *)videoIdentifier completionHandler:(void (^)(XCDYouTubeVideo * _Nullable video, NSError * _Nullable error))completionHandler
 {
 	if (!completionHandler)
 		@throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"The `completionHandler` argument must not be nil." userInfo:nil];


### PR DESCRIPTION
Hi,

I have use this library and I want to say thank you.

Currently I use this library with swift project via Carthage.

Today , I tried to migrate my project from swift 1.2 to swift 2.0.
However the signature of completionHandler function of getVideoWithIdentifie is changed.

In swift 2.0, both video and  error are non-optional value,
I can't check if video exists.

So, I try to fix it by adding `_Nullable` annotation to callback function.

:(NSString *)videoIdentifier completionHandler:(void (^)(XCDYouTubeVideo * _Nullable video, NSError * _Nullable error))completionHandler

Please use it as a reference.

Thank you.