### PR TITLE
Error should always contain the video

### DIFF
--- a/XCDYouTubeKit/XCDYouTubeVideo.m
+++ b/XCDYouTubeKit/XCDYouTubeVideo.m
@@ -107,6 +107,7 @@ static NSDate * ExpirationDate(NSURL *streamURL)
 	NSString *adaptiveFormats = info[@"adaptive_fmts"];
 	
 	NSMutableDictionary *userInfo = response.URL ? [@{ NSURLErrorKey: response.URL } mutableCopy] : [NSMutableDictionary new];
+	userInfo[@"XCDYouTubeVideo"] = self;
 	
 	if (streamMap.length > 0 || httpLiveStream.length > 0)
 	{

--- a/XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.h
+++ b/XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.h
@@ -10,6 +10,8 @@
 #endif
 
 #import <MediaPlayer/MediaPlayer.h>
+#import <AVKit/AVKit.h>
+#import <AVFoundation/AVFoundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -42,10 +44,8 @@ MP_EXTERN NSString *const XCDYouTubeVideoUserInfoKey;
  *
  *  Use the `<presentInView:>` method to play a YouTube video inline.
  */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-@interface XCDYouTubeVideoPlayerViewController : MPMoviePlayerViewController
-#pragma clang diagnostic pop
+
+@interface XCDYouTubeVideoPlayerViewController : AVPlayerViewController
 
 /**
  *  ------------------

--- a/XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.m
+++ b/XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.m
@@ -70,7 +70,7 @@ NSString *const XCDYouTubeVideoUserInfoKey = @"Video";
 #endif
 	
 	if ([[[UIDevice currentDevice] systemVersion] integerValue] >= 8)
-		self = [super initWithContentURL:nil];
+		self = [super init];
 	else
 		self = [super init]; // LCOV_EXCL_LINE
 	
@@ -139,12 +139,17 @@ NSString *const XCDYouTubeVideoUserInfoKey = @"Video";
 	
 	self.embedded = YES;
 	
+	NSLog(@"EMBED DEPRECATED");
+	
+	/*
 	self.moviePlayer.controlStyle = MPMovieControlStyleEmbedded;
 	self.moviePlayer.view.frame = CGRectMake(0, 0, view.bounds.size.width, view.bounds.size.height);
 	self.moviePlayer.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 	if (![view.subviews containsObject:self.moviePlayer.view])
 		[view addSubview:self.moviePlayer.view];
 	objc_setAssociatedObject(view, XCDYouTubeVideoPlayerViewControllerKey, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	*/
+	
 }
 
 #pragma mark - Private
@@ -166,21 +171,17 @@ NSString *const XCDYouTubeVideoUserInfoKey = @"Video";
 	[[NSNotificationCenter defaultCenter] postNotificationName:XCDYouTubeVideoPlayerViewControllerDidReceiveMetadataNotification object:self userInfo:userInfo];
 #pragma clang diagnostic pop
 	
-	self.moviePlayer.contentURL = streamURL;
+	self.player = [AVPlayer playerWithURL:streamURL];
 	
 	[[NSNotificationCenter defaultCenter] postNotificationName:XCDYouTubeVideoPlayerViewControllerDidReceiveVideoNotification object:self userInfo:@{ XCDYouTubeVideoUserInfoKey: video }];
 }
 
 - (void) stopWithError:(NSError *)error
 {
-	NSDictionary *userInfo = @{ MPMoviePlayerPlaybackDidFinishReasonUserInfoKey: @(MPMovieFinishReasonPlaybackError),
-	                            XCDMoviePlayerPlaybackDidFinishErrorUserInfoKey: error };
-	[[NSNotificationCenter defaultCenter] postNotificationName:MPMoviePlayerPlaybackDidFinishNotification object:self.moviePlayer userInfo:userInfo];
+	NSDictionary *userInfo = @{ XCDMoviePlayerPlaybackDidFinishErrorUserInfoKey: error };
+	[[NSNotificationCenter defaultCenter] postNotificationName:MPMoviePlayerPlaybackDidFinishNotification object:self userInfo:userInfo];
 	
-	if (self.isEmbedded)
-		[self.moviePlayer.view removeFromSuperview];
-	else
-		[self.presentingViewController dismissMoviePlayerViewControllerAnimated];
+	[self.presentingViewController dismissMoviePlayerViewControllerAnimated];
 }
 
 #pragma mark - UIViewController
@@ -192,8 +193,8 @@ NSString *const XCDYouTubeVideoUserInfoKey = @"Video";
 	if (![self isBeingPresented])
 		return;
 	
-	self.moviePlayer.controlStyle = MPMovieControlStyleFullscreen;
-	[self.moviePlayer play];
+	[self.player play];
+	
 }
 
 - (void) viewWillDisappear:(BOOL)animated


### PR DESCRIPTION
The returned error should always contain the video object... this can be desired in the case of a fallback behaviour, when the direct video streaming is not available, but the app wants to show the thumb, title etc and probably open a webview
