### PR TITLE
Add support for presenting the video inside a view with a control style

### DIFF
--- a/XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.h
+++ b/XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.h
@@ -108,6 +108,17 @@ MP_EXTERN NSString *const XCDYouTubeVideoUserInfoKey;
  */
 - (void) presentInView:(UIView *)view;
 
+/**
+ *  Present the video inside a view with a control style.
+ *
+ *  @param view The view inside which you want to present the video.
+ *  @param controlStyle The control style which you want to use.
+ *
+ *  @discussion The video view is added as a subview of the specified view. The video does not start playing immediately, you have to call `[videoPlayerViewController.moviePlayer play]` for playback to start. See `MPMoviePlayerController` documentation for more information.
+ *
+ *  Ownership of the XCDYouTubeVideoPlayerViewController instance is transferred to the view.
+ */
+- (void) presentInView:(UIView *)view controlStyle:(MPMovieControlStyle)controlStyle;
 @end
 
 /**

--- a/XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.m
+++ b/XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.m
@@ -133,18 +133,23 @@ NSString *const XCDYouTubeVideoUserInfoKey = @"Video";
 	}];
 }
 
-- (void) presentInView:(UIView *)view
+- (void) presentInView:(UIView *)view controlStyle:(MPMovieControlStyle)controlStyle
 {
 	static const void * const XCDYouTubeVideoPlayerViewControllerKey = &XCDYouTubeVideoPlayerViewControllerKey;
-	
+
 	self.embedded = YES;
-	
-	self.moviePlayer.controlStyle = MPMovieControlStyleEmbedded;
+
+	self.moviePlayer.controlStyle = controlStyle;
 	self.moviePlayer.view.frame = CGRectMake(0.f, 0.f, view.bounds.size.width, view.bounds.size.height);
 	self.moviePlayer.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 	if (![view.subviews containsObject:self.moviePlayer.view])
 		[view addSubview:self.moviePlayer.view];
 	objc_setAssociatedObject(view, XCDYouTubeVideoPlayerViewControllerKey, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (void) presentInView:(UIView *)view
+{
+	[self presentInView:view controlStyle:MPMovieControlStyleEmbedded];
 }
 
 #pragma mark - Private


### PR DESCRIPTION
Hi,

I'm also troubled by this issue https://github.com/0xced/XCDYouTubeKit/issues/221.
Can't use custom movie controls by the issue.

So, I added a method below
```
- (void)presentInView:(nonnull UIView *)view controlStyle:(MPMovieControlStyle)controlStyle;
```
I hope this will help you.

Thanks