### PR TITLE
Extract anonymous function to access signature function

### DIFF
--- a/XCDYouTubeKit/XCDYouTubePlayerScript.m
+++ b/XCDYouTubeKit/XCDYouTubePlayerScript.m
@@ -21,6 +21,18 @@
 		return nil; // LCOV_EXCL_LINE
 	
 	NSString *script = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+	if ([script hasPrefix:@"var _yt_player={};(function(g){"]) {
+		script = [script stringByReplacingOccurrencesOfString:@"var _yt_player={};(function(g){" withString:@"g={};"];
+		script = [script stringByReplacingOccurrencesOfString:@"})(_yt_player);" withString:@";_yt_player=g;"];
+	}
+	else {
+		NSRegularExpression *anonymousFunctionRegularExpression = [NSRegularExpression regularExpressionWithPattern:@"\\(function\\([^)]*\\)\\{(.*)\\}\\)\\([^)]*\\)" options:NSRegularExpressionDotMatchesLineSeparators error:NULL];		
+		NSTextCheckingResult *anonymousFunctionResult = [anonymousFunctionRegularExpression firstMatchInString:script options:(NSMatchingOptions)0 range:NSMakeRange(0, script.length)];		
+		if (anonymousFunctionResult.numberOfRanges > 1)		
+			script = [script substringWithRange:[anonymousFunctionResult rangeAtIndex:1]];		
+		else
+			XCDYouTubeLogWarning(@"Unexpected player script (no anonymous function found)");
+	}
 	
 	_context = [JSContext new];
 	_context.exceptionHandler = ^(JSContext *context, JSValue *exception) {

--- a/XCDYouTubeKit/XCDYouTubePlayerScript.m
+++ b/XCDYouTubeKit/XCDYouTubePlayerScript.m
@@ -21,12 +21,6 @@
 		return nil; // LCOV_EXCL_LINE
 	
 	NSString *script = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-	NSRegularExpression *anonymousFunctionRegularExpression = [NSRegularExpression regularExpressionWithPattern:@"\\(function\\([^)]*\\)\\{(.*)\\}\\)\\([^)]*\\)" options:NSRegularExpressionDotMatchesLineSeparators error:NULL];
-	NSTextCheckingResult *anonymousFunctionResult = [anonymousFunctionRegularExpression firstMatchInString:script options:(NSMatchingOptions)0 range:NSMakeRange(0, script.length)];
-	if (anonymousFunctionResult.numberOfRanges > 1)
-		script = [script substringWithRange:[anonymousFunctionResult rangeAtIndex:1]];
-	else
-		XCDYouTubeLogWarning(@"Unexpected player script (no anonymous function found)");
 	
 	_context = [JSContext new];
 	_context.exceptionHandler = ^(JSContext *context, JSValue *exception) {


### PR DESCRIPTION
According to this issue: https://github.com/0xced/XCDYouTubeKit/issues/120

Replaces this code:
```javascript
var _yt_player={};(function(g){ … })(_yt_player);
```

with this one:
```javascript
g={}; … ;_yt_player=g;
```