### PR TITLE
Prevent setting a dictionary value to nil as this crashes on iOS 7

### DIFF
--- a/XCDYouTubeKit/XCDYouTubeVideo.m
+++ b/XCDYouTubeKit/XCDYouTubeVideo.m
@@ -32,7 +32,11 @@ NSDictionary *XCDDictionaryWithQueryString(NSString *string)
 				                     @"Query: %@\n"
 				                     @"Discarded value: %@", key, string, dictionary[key]);
 			}
-			dictionary[key] = value;
+
+			if (value)
+			{
+				dictionary[key] = value;
+			}
 		}
 	}
 	return [dictionary copy];


### PR DESCRIPTION
We're currently seeing a lot of crashes exclusively on iOS 7 in XCDYouTubeVideo.m:28. This happens during the parsing of the query string. The call to `- stringByRemovingPercentEncoding` fails and `dictionary[key] = value` is called with a nil value, which isn't safe on iOS 7.

```
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x2e4dff83 __exceptionPreprocess
1  libobjc.A.dylib                0x38c90ccf objc_exception_throw
2  CoreFoundation                 0x2e41b8f3 -[__NSDictionaryM setObject:forKey:]
3  ADW                            0x3f9f1b XCDDictionaryWithQueryString (XCDYouTubeVideo.m:28)
4  ADW                            0x3fa9e9 -[XCDYouTubeVideo initWithIdentifier:info:playerScript:response:error:] (XCDYouTubeVideo.m:112)
5  ADW                            0x3fc349 -[XCDYouTubeVideoOperation handleVideoInfoResponseWithInfo:response:] (XCDYouTubeVideoOperation.m:175)
6  ADW                            0x3fcb95 -[XCDYouTubeVideoOperation handleJavaScriptPlayerWithData:response:] (XCDYouTubeVideoOperation.m:258)
7  ADW                            0x3fc0d5 -[XCDYouTubeVideoOperation handleConnectionSuccessWithData:response:requestType:] (XCDYouTubeVideoOperation.m:156)
8  ADW                            0x3fbfed __53-[XCDYouTubeVideoOperation startRequestWithURL:type:]_block_invoke91 (XCDYouTubeVideoOperation.m:127)
9  CFNetwork                      0x2e0f93d5 __49-[__NSCFLocalSessionTask _task_onqueue_didFinish]_block_invoke
10 Foundation                     0x2ee243c7 -[NSBlockOperation main]
11 Foundation                     0x2ee145ab -[__NSOperationInternal _start:]
12 Foundation                     0x2eeb876d __NSOQSchedule_f
13 libdispatch.dylib              0x39178ded _dispatch_queue_drain$VARIANT$up
14 libdispatch.dylib              0x39179297 _dispatch_queue_invoke$VARIANT$up
15 libdispatch.dylib              0x3918b88d _dispatch_root_queue_drain
16 libdispatch.dylib              0x3918bb21 _dispatch_worker_thread2
17 libsystem_pthread.dylib        0x392babd3 _pthread_wqthread
18 libsystem_pthread.dylib        0x392baa98 start_wqthread
```
