### PR TITLE
Add support for SwiftPM based dependency managers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "XCDYouTubeKit",
+    // platforms: [.iOS("8.0"), .macOS("10.10"), tvOS("9.0")],
+    products: [
+        .library(name: "XCDYouTubeKit", targets: ["XCDYouTubeKit"])
+    ],
+    targets: [
+        .target(
+            name: "XCDYouTubeKit",
+            path: "XCDYouTubeKit"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Platform](https://img.shields.io/cocoapods/p/XCDYouTubeKit.svg?style=flat)](http://cocoadocs.org/docsets/XCDYouTubeKit/)
 [![Pod Version](https://img.shields.io/cocoapods/v/XCDYouTubeKit.svg?style=flat)](https://cocoapods.org/pods/XCDYouTubeKit)
 [![Carthage Compatibility](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage/)
+[![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio)
 [![License](https://img.shields.io/cocoapods/l/XCDYouTubeKit.svg?style=flat)](LICENSE)
 
 **XCDYouTubeKit** is a YouTube video player for iOS, tvOS and macOS.
@@ -27,7 +28,7 @@ XCDYouTubeKit is against the YouTube [Terms of Service](https://www.youtube.com/
 
 ## Installation
 
-XCDYouTubeKit is available through CocoaPods and Carthage.
+XCDYouTubeKit is available through [CocoaPods](https://cocoapods.org/), [Carthage](https://github.com/Carthage/Carthage) and [Accio](https://github.com/JamitLabs/Accio).
 
 CocoaPods:
 
@@ -39,6 +40,12 @@ Carthage:
 
 ```objc
 github "0xced/XCDYouTubeKit" ~> 2.7
+```
+
+Accio:
+
+```swift
+.package(url: "https://github.com/0xced/XCDYouTubeKit.git", .upToNextMajor(from: "2.7.3")),
 ```
 
 Alternatively, you can manually use the provided static library or dynamic framework. In order to use the static library, you must:


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).