### PR TITLE
Return additional metadata

### DIFF
--- a/XCDYouTubeKit/XCDYouTubeVideo.h
+++ b/XCDYouTubeKit/XCDYouTubeVideo.h
@@ -70,6 +70,18 @@ extern NSString *const XCDYouTubeVideoQualityHTTPLiveStreaming;
  */
 @property (nonatomic, readonly) NSString *title;
 /**
+ * The author of the video
+ */
+@property (nonatomic, readonly) NSString *author;
+/**
+ * The channeId of the video
+ */
+@property (nonatomic, readonly) NSString *channelId;
+/**
+ * The description of the video
+ */
+@property (nonatomic, readonly) NSString *videoDescription;
+/**
  *  The duration of the video in seconds.
  */
 @property (nonatomic, readonly) NSTimeInterval duration;

--- a/XCDYouTubeKit/XCDYouTubeVideo.m
+++ b/XCDYouTubeKit/XCDYouTubeVideo.m
@@ -198,6 +198,21 @@ static NSDate * ExpirationDate(NSURL *streamURL)
 			title = @"";
 		_title = title;
 		
+		NSString *author = info[@"author"] == nil? videoDetails[@"author"] : info[@"author"];
+		if (author == nil)
+			author = @"";
+		_author = author;
+		
+		NSString *channelId = info[@"ucid"] == nil? videoDetails[@"channelId"] : info[@"ucid"];
+		if (channelId == nil)
+			channelId = @"";
+		_channelId = channelId;
+		
+		NSString *description = videoDetails[@"shortDescription"];
+		if (description == nil)
+			description = @"";
+		_videoDescription = description;
+		
 		_viewCount = info[@"viewCount"] == nil? [(NSString *)videoDetails[@"viewCount"] integerValue] : [(NSString *)info[@"viewCount"] integerValue];
 		
 		_duration = info[@"length_seconds"] == nil? [(NSString *)videoDetails[@"lengthSeconds"] doubleValue] : [(NSString *)info[@"length_seconds"] doubleValue];


### PR DESCRIPTION
We needed some additional metadata that was already available in the info and videoDetails dicts so I added them to XCDYouTubeVideo.h. Description doesn't have a fallback but the others do. They all default to empty strings when nil in line with title, etc.