### PR TITLE
Exclude plist files from SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,11 @@ let package = Package(
         .target(
             name: "XCDYouTubeKit",
             path: ".",
+            exclude: [
+                "XCDYouTubeKit/Info.plist",
+                "XCDYouTubeKit/Configuration.plist",
+                "XCDYouTubeKit/AppledocSettings.plist"
+            ],
             sources: ["XCDYouTubeKit"],
             publicHeadersPath: "XCDYouTubeKit"
         )


### PR DESCRIPTION
At the moment when building the library via SPM, it produces 3 warnings because plist files are added in the project as compilable files.
This PR excludes them from SPM

About warning: https://stackoverflow.com/questions/6509600/compilation-warning-no-rule-to-process-file-for-architecture-i386

Screenshot:
<img width="464" alt="warnings" src="https://user-images.githubusercontent.com/4473783/80315977-6fc5da80-87fb-11ea-874b-62f68af0c427.png">
