### PR TITLE
Add missing reference for UIKit in ios build target

### DIFF
--- a/XCDYouTubeKit.podspec
+++ b/XCDYouTubeKit.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.public_header_files    = "XCDYouTubeKit/XCDYouTube{Client,Error,Kit,Logger,Operation,Video,VideoOperation,VideoQueryOperation,VideoPlayerViewController}.h"
   s.osx.exclude_files      = "XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.{h,m}"
   s.tvos.exclude_files     = "XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.{h,m}"
-  s.ios.frameworks         = "JavaScriptCore", "MediaPlayer"
+  s.ios.frameworks         = "JavaScriptCore", "MediaPlayer", "UIKit"
   s.osx.frameworks         = "JavaScriptCore"
   s.tvos.frameworks        = "JavaScriptCore"
   s.requires_arc           = true


### PR DESCRIPTION
At the moment if we're building this framework with CocoaPods and use_frameworks! and use_modular_headers! enabled, there is a missing reference to UIKit framework

At XCDYouTubeVideoPlayerViewController.m line 76 we're using UIDevice reference. 

If we're manually add this framework at project Link With Binary build phase everything works fine

```
if ([[[UIDevice currentDevice] systemVersion] integerValue] >= 8)
```

this issue will arise if CLANG_MODULES_AUTOLINK set to 'NO'