### PR TITLE
Replace deprecated GoogleAPIClient in tvOS demo

### DIFF
--- a/XCDYouTubeKit Demo/Podfile
+++ b/XCDYouTubeKit Demo/Podfile
@@ -19,5 +19,5 @@ end
 
 target 'XCDYouTubeKit tvOS Demo' do
   platform :tvos, '9.0'
-  pod 'GoogleAPIClient/YouTube', '~> 1.0'
+  pod 'GoogleAPIClientForREST/YouTube', '~> 1.5'
 end

--- a/XCDYouTubeKit Demo/tvOS Demo/PlaylistCollectionViewController.m
+++ b/XCDYouTubeKit Demo/tvOS Demo/PlaylistCollectionViewController.m
@@ -5,7 +5,7 @@
 #import "PlaylistCollectionViewController.h"
 
 #import <AVKit/AVKit.h>
-#import <GoogleAPIClient/GTLYouTube.h>
+#import <GoogleAPIClientForREST/GTLRYouTube.h>
 #import <XCDYouTubeKit/XCDYouTubeKit.h>
 
 #import "VideoCell.h"
@@ -65,7 +65,7 @@
 
 - (void) collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath;
 {
-	GTLYouTubePlaylistItem *playlistItem = self.items[indexPath.row];
+	GTLRYouTube_PlaylistItem *playlistItem = self.items[indexPath.row];
 	
 	AVPlayerViewController *playerViewController = [AVPlayerViewController new];
 	[self presentViewController:playerViewController animated:YES completion:nil];

--- a/XCDYouTubeKit Demo/tvOS Demo/VideoCell.h
+++ b/XCDYouTubeKit Demo/tvOS Demo/VideoCell.h
@@ -4,10 +4,10 @@
 
 #import <UIKit/UIKit.h>
 
-#import <GoogleAPIClient/GTLYouTube.h>
+#import <GoogleAPIClientForREST/GTLRYouTube.h>
 
 @interface VideoCell : UICollectionViewCell
 
-@property (nonatomic, strong) GTLYouTubePlaylistItem *playlistItem;
+@property (nonatomic, strong) GTLRYouTube_PlaylistItem *playlistItem;
 
 @end

--- a/XCDYouTubeKit Demo/tvOS Demo/VideoCell.m
+++ b/XCDYouTubeKit Demo/tvOS Demo/VideoCell.m
@@ -26,6 +26,7 @@
 	_playlistItem = playlistItem;
 	
 	self.titleLabel.text = playlistItem.snippet.title;
+	self.titleLabel.textColor = [UIColor blackColor];
 	
 	GTLRYouTube_ThumbnailDetails *thumbnails = playlistItem.snippet.thumbnails;
 	GTLRYouTube_Thumbnail *thumbnail = thumbnails.maxres ?: thumbnails.high ?: thumbnails.medium ?: thumbnails.standard;

--- a/XCDYouTubeKit Demo/tvOS Demo/VideoCell.m
+++ b/XCDYouTubeKit Demo/tvOS Demo/VideoCell.m
@@ -21,15 +21,16 @@
 	[self.imageDataTask cancel];
 }
 
-- (void) setPlaylistItem:(GTLYouTubePlaylistItem *)playlistItem
+- (void) setPlaylistItem:(GTLRYouTube_PlaylistItem *)playlistItem
 {
 	_playlistItem = playlistItem;
 	
 	self.titleLabel.text = playlistItem.snippet.title;
 	
-	GTLYouTubeThumbnailDetails *thumbnails = playlistItem.snippet.thumbnails;
-	GTLYouTubeThumbnail *thumbnail = thumbnails.maxres ?: thumbnails.high ?: thumbnails.medium ?: thumbnails.standard;
+	GTLRYouTube_ThumbnailDetails *thumbnails = playlistItem.snippet.thumbnails;
+	GTLRYouTube_Thumbnail *thumbnail = thumbnails.maxres ?: thumbnails.high ?: thumbnails.medium ?: thumbnails.standard;
 	NSURL *thumbnailURL = [NSURL URLWithString:thumbnail.url];
+
 	self.imageDataTask = [[NSURLSession sharedSession] dataTaskWithURL:thumbnailURL completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
 		dispatch_async(dispatch_get_main_queue(), ^{
 			self.imageView.image = self.playlistItem == playlistItem ? [UIImage imageWithData:data] : nil;


### PR DESCRIPTION
This pull request replaces the `GoogleAPIClient` pod with `GoogleAPIClientForREST`, the old library stopped working in [March 2019](https://github.com/google/google-api-objectivec-client). A minor visual bug was also fixed with the initial video label text color.