### PR TITLE
Changed for query update needed, June 2021 Google update

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/XCDYouTubeKit/XCDYouTubeVideoOperation.m
+++ b/XCDYouTubeKit/XCDYouTubeVideoOperation.m
@@ -129,31 +129,39 @@ static NSError *YouTubeError(NSError *error, NSSet *regionsAllowed, NSString *la
 
 - (void) startNextRequest
 {
-	if (self.eventLabels.count == 0)
-	{
-		if (self.requestType == XCDYouTubeRequestTypeWatchPage || self.webpage)
-		{
-			if (self.ranLastEmbedPage == NO) {
-				[self startLastEmbedPageRequest];
-				return;
-			}
-			[self finishWithError];
-		}
-		else
-		{
-			[self startWatchPageRequest];
-		}
-	}
-	else
-	{
-		NSString *eventLabel = [self.eventLabels objectAtIndex:0];
-		[self.eventLabels removeObjectAtIndex:0];
-		
-		NSDictionary *query = @{ @"video_id": self.videoIdentifier, @"hl": self.languageIdentifier, @"el": eventLabel, @"ps": @"default" };
-		NSString *queryString = XCDQueryStringWithDictionary(query);
-		NSURL *videoInfoURL = [NSURL URLWithString:[@"https://www.youtube.com/get_video_info?" stringByAppendingString:queryString]];
-		[self startRequestWithURL:videoInfoURL type:XCDYouTubeRequestTypeGetVideoInfo];
-	}
+    if (self.eventLabels.count == 0)
+    {
+        if (self.requestType == XCDYouTubeRequestTypeWatchPage || self.webpage)
+        {
+            if (self.ranLastEmbedPage == NO) {
+                [self startLastEmbedPageRequest];
+                return;
+            }
+            [self finishWithError];
+        }
+        else
+        {
+            [self startWatchPageRequest];
+        }
+    }
+    else
+    {
+        NSString *eventLabel = [self.eventLabels objectAtIndex:0];
+        [self.eventLabels removeObjectAtIndex:0];
+
+        NSDictionary *query = @{ @"video_id": self.videoIdentifier,
+                                 @"hl": self.languageIdentifier,
+                                 @"el": eventLabel,
+                                 @"ps": @"default",
+                                 @"html5" : @"1",
+                                 @"eurl": [@"https://youtube.googleapis.com/v/" stringByAppendingString: self.videoIdentifier],
+                                 @"c": @"TVHTML5",
+                                 @"cver": @"6.20180913"};
+
+        NSString *queryString = XCDQueryStringWithDictionary(query);
+        NSURL *videoInfoURL = [NSURL URLWithString:[@"https://www.youtube.com/get_video_info?" stringByAppendingString:queryString]];
+        [self startRequestWithURL:videoInfoURL type:XCDYouTubeRequestTypeGetVideoInfo];
+    }
 }
 
 - (void) startWatchPageRequest


### PR DESCRIPTION
```
        NSDictionary *query = @{ @"video_id": self.videoIdentifier,
                                 @"hl": self.languageIdentifier,
                                 @"el": eventLabel,
                                 @"ps": @"default",
                                 @"html5" : @"1",
                                 @"eurl": [@"https://youtube.googleapis.com/v/" stringByAppendingString: self.videoIdentifier],
                                 @"c": @"TVHTML5",
                                 @"cver": @"6.20180913"};
```