### PR TITLE
get video info via post request using innertube api key

### DIFF
--- a/XCDYouTubeKit/XCDYouTubeClient.h
+++ b/XCDYouTubeKit/XCDYouTubeClient.h
@@ -25,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface XCDYouTubeClient : NSObject
 
++ (NSString *)innertubeApiKey;
++ (void)setInnertubeApiKey:(NSString *)key;
+
 /**
  *  ------------------
  *  @name Initializing

--- a/XCDYouTubeKit/XCDYouTubeClient.m
+++ b/XCDYouTubeKit/XCDYouTubeClient.m
@@ -14,6 +14,8 @@
 
 @synthesize languageIdentifier = _languageIdentifier;
 
+static NSString * _innertubeApiKey = @"AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
+
 + (instancetype) defaultClient
 {
 	static XCDYouTubeClient *defaultClient;
@@ -27,6 +29,15 @@
 - (instancetype) init
 {
 	return [self initWithLanguageIdentifier:nil];
+}
+
+
++ (NSString *)innertubeApiKey {
+	return _innertubeApiKey;
+}
+
++ (void)setInnertubeApiKey:(NSString *)key {
+	_innertubeApiKey = key;
 }
 
 - (instancetype) initWithLanguageIdentifier:(NSString *)languageIdentifier


### PR DESCRIPTION
the innertube api key is hardcoded and we don't know how long it will last so it is recommended to scrap the api key from youtube and set it via _XCDYouTubeClient.setInnertubeApiKey_

```
func scrapInnertubeApiKey(){
    let link = "https://www.youtube.com"
    Alamofire.request(link).responseString { (response) in  // network lib https://github.com/Alamofire/Alamofire
        if let html = response.value {
            if let doc = try? HTML(html: html, encoding: .utf8) {   // HTML parser https://github.com/tid-kijyun/Kanna
                if let text = doc.xpath("//script[contains(., 'INNERTUBE_API_KEY')]/text()").first?.text {
                    if let results = text.match("ytcfg.set\\((\\{.*?\\})\\)").last?.last {
                        if let data = results.data(using: .utf8), let model = try? JSONDecoder().decode(InnertubeScrap.self, from: data) {
                            let key = model.INNERTUBE_API_KEY
                            XCDYouTubeClient.setInnertubeApiKey(key)
                        }
                    }
                }
            }
        }
    }
}


struct InnertubeScrap : Codable {
    let INNERTUBE_API_KEY : String
}

extension String {
    func match(_ regex: String) -> [[String]] {
        let nsString = self as NSString
        return (try? NSRegularExpression(pattern: regex, options: []))?.matches(in: self, options: [], range: NSMakeRange(0, nsString.length)).map { match in
            (0..<match.numberOfRanges).map { match.range(at: $0).location == NSNotFound ? "" : nsString.substring(with: match.range(at: $0)) }
        } ?? []
    }
}
```